### PR TITLE
fix: adjust navbar button sizes for mobile layout

### DIFF
--- a/pkg/main/routes/(common)/(_components)/header.tsx
+++ b/pkg/main/routes/(common)/(_components)/header.tsx
@@ -148,7 +148,7 @@ export const Header = (props: HeaderProps) => {
             </div>
           </div> */
           }
-          <a href="https://www.youtube.com/@eserlive/live" class="btn btn-error" target="_blank" rel="noreferrer">
+          <a href="https://www.youtube.com/@eserlive/live" class="btn btn-sm md:btn btn-error" target="_blank" rel="noreferrer">
             <IconBrandYouTube class="h-6 w-6" />
             <span class="inline md:hidden">Canlı</span>
             <span class="hidden md:inline">Canlı Yayın</span>
@@ -181,7 +181,7 @@ export const Header = (props: HeaderProps) => {
               </div>
             )
             : (
-              <a href="/auth/login" tabIndex={0} role="button" class="btn btn-neutral">
+              <a href="/auth/login" tabIndex={0} role="button" class="btn btn-sm md:btn btn-neutral">
                 <span class="inline md:hidden">Giriş</span>
                 <span class="hidden md:inline">GitHub ile Giriş</span>
               </a>


### PR DESCRIPTION
## Fixes issue

<!-- If your PR fixes an open issue, use `Fixes #ISSUE_NUMBER` to link your PR with the issue. -->

Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->

Github Login and Live Stream buttons have been resized in mobile screens due to their vertical size exceeding the page title

## Check List (Check all the applicable boxes)

- [x] The title of my pull request is a short description of the requested changes.
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] This PR does not contain plagiarized content.
- [x] My submissions follows the **Submission Rules**
- [x] I have read and accepted the **Code of Conduct**

## Screenshots

<!-- Add all the screenshots which support your changes -->

<img width="632" alt="image" src="https://github.com/user-attachments/assets/e74b4ea7-7294-4fc7-a19c-ff2a4b68a863">


## Note to reviewers

<!-- Add notes to reviewers if applicable -->
